### PR TITLE
Fix: Crash when panning

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -246,7 +246,7 @@ open class ChartDataSet: ChartBaseDataSet
         rounding: ChartDataSetRounding) -> Int
     {
         var closest = partitioningIndex { $0.x >= xValue }
-        guard closest < endIndex else { return -1 }
+        guard closest < endIndex else { return entries.count - 1 }
 
         let closestXValue = self[closest].x
 


### PR DESCRIPTION
**Issue**
A crash would sometimes occur when panning. This was caused by a function that would sometimes return an index of `-1`.

**Solution**
Changed the function to return the last index of the array in question instead.