### PR TITLE
Fixed crash by handling index return of -1

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -101,8 +101,10 @@ open class ChartDataSet: ChartBaseDataSet
 
         guard !isEmpty else { return }
         
-        let indexFrom = entryIndex(x: fromX, closestToY: .nan, rounding: .down)
-        let indexTo = entryIndex(x: toX, closestToY: .nan, rounding: .up)
+        var indexFrom = entryIndex(x: fromX, closestToY: .nan, rounding: .down)
+        var indexTo = entryIndex(x: toX, closestToY: .nan, rounding: .up)
+        if indexFrom == -1 { indexFrom = 0 }
+        if indexTo == -1 { indexTo = entries.count - 1 }
         
         guard indexTo >= indexFrom else { return }
         calcMinMaxY(fromX: fromX, toX: toX, entries: Array(entries[indexFrom...indexTo]))
@@ -208,7 +210,7 @@ open class ChartDataSet: ChartBaseDataSet
         {
             return self[index]
         }
-        return nil
+        return entries.last
     }
     
     /// - Parameters:


### PR DESCRIPTION
**Issue**
A crash would sometimes occur when panning. This was caused by a function sometimes returning an index of -1, which was not properly handled.

**Solution**
Handled the edge cases by using first/last index of the array in question instead.