### PR TITLE
Fix: Crash when toggling chart

### DIFF
--- a/Source/Charts/Renderers/LineChartRenderer.swift
+++ b/Source/Charts/Renderers/LineChartRenderer.swift
@@ -760,7 +760,8 @@ open class LineChartRenderer: LineRadarRenderer
         
         for high in indices
         {
-            guard let set = lineData[high.dataSetIndex] as? LineChartDataSetProtocol,
+            guard high.dataSetIndex < lineData.count,
+                  let set = lineData[high.dataSetIndex] as? LineChartDataSetProtocol,
                   set.isHighlightEnabled
             else { continue }
             


### PR DESCRIPTION
**Problem**
The app would sometimes crash when toggling different data in the chart.

**Solution**
Added guard statement to protect against out of range access.