### PR TITLE
Fix: all values not selectable

### DIFF
--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -230,10 +230,9 @@ open class ChartDataSet: ChartBaseDataSet
     /// An empty array if no Entry object at that index.
     open override func entriesForXValue(_ xValue: Double) -> [ChartDataEntry]
     {
-        let match: (ChartDataEntry) -> Bool = { $0.x == xValue }
-        let i = partitioningIndex(where: match)
+        let i = partitioningIndex(where: { $0.x >= xValue })
         guard i < endIndex else { return [] }
-        return self[i...].prefix(while: match)
+        return self[i...].prefix(while: { $0.x == xValue })
     }
     
     /// - Parameters:
@@ -247,9 +246,20 @@ open class ChartDataSet: ChartBaseDataSet
         closestToY yValue: Double,
         rounding: ChartDataSetRounding) -> Int
     {
-        var closest = partitioningIndex { $0.x >= xValue }
-        guard closest < endIndex else { return -1 }
-
+        let nextClosestIndex = partitioningIndex { $0.x >= xValue }
+        
+        guard nextClosestIndex < endIndex else { return -1 }
+        var closest = nextClosestIndex
+        
+        let prevClosestIndex = nextClosestIndex - 1
+        
+        if prevClosestIndex > startIndex {
+            let nextXValueDistance = self[nextClosestIndex].x - xValue
+            let prevXValueDistance = xValue - self[prevClosestIndex].x
+            let closestXValueIndex = prevXValueDistance > nextXValueDistance ? nextClosestIndex : prevClosestIndex
+            closest = closestXValueIndex
+        }
+        
         let closestXValue = self[closest].x
 
         switch rounding {


### PR DESCRIPTION
**Problem**
Some values in the charts could not be selected

**Solution**
Updated `entriesForXValue()` and `entryIndex(x:, closestToY:, rounding:)` in `ChartDataSet` with solution found [here](https://github.com/danielgindi/Charts/pull/4817/files).